### PR TITLE
Expose a method to manually close the connection to redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ server.add_extension Faye::Reconnect::ServerExtension.new(server)
 
 ### Client Side
 
-The client extension has a dependency on redis. 
+The client extension has a dependency on redis.
 It uses redis to persist the client id after each successful handshake so it can re-use it when trying to reconnect.
 
 Add the extension to your faye client :
@@ -66,7 +66,7 @@ If you don't specify redis options, the ones provided in the above example will 
 You may already have something along the lines of :
 
 ```ruby
-trap('TERM') do 
+trap('TERM') do
     client.disconnect
 end
 ```
@@ -74,7 +74,7 @@ end
 If you plan on reconnecting with the same client id and get missing messages, you have to use the ``stop!`` method provided by this gem :
 
 ```ruby
-trap('TERM') do 
+trap('TERM') do
     client.stop!
 end
 ```
@@ -84,7 +84,7 @@ Instead of sending a ``/meta/disconnect`` message to the server, it will cleanly
 
 ## Contributing
 
-1. Fork it ( https://github.com/dimelo/faye-reconnect/fork )
+1. Fork it (https://github.com/jarthod/faye-reconnect/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/faye/reconnect/client_extension.rb
+++ b/lib/faye/reconnect/client_extension.rb
@@ -32,6 +32,10 @@ module Faye
         "#{@name}/client_id"
       end
 
+      def close_redis_connection
+        @redis&.close_connection
+      end
+
       def fetch_client_id(&callback)
         if @clientIdFetched == false
           @clientIdFetched = true

--- a/lib/faye/reconnect/version.rb
+++ b/lib/faye/reconnect/version.rb
@@ -1,5 +1,5 @@
 module Faye
   module Reconnect
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/spec/client_extension_spec.rb
+++ b/spec/client_extension_spec.rb
@@ -3,7 +3,6 @@ require 'faye/reconnect'
 require 'spec_helper'
 
 describe Faye::Reconnect::ClientExtension do
-
   it 'requires a name option' do
     expect {
       Faye::Reconnect::ClientExtension.new
@@ -13,4 +12,11 @@ describe Faye::Reconnect::ClientExtension do
     }.to_not raise_error
   end
 
+  describe '#close_redis_connection' do
+    it 'calls #close_connection on the redis client' do
+      faye_reconnect = Faye::Reconnect::ClientExtension.new(name: 'foobar')
+      expect_any_instance_of(EventMachine::Hiredis::Client).to receive(:close_connection).and_return(true)
+      faye_reconnect.close_redis_connection
+    end
+  end
 end


### PR DESCRIPTION
Hey !

Here's a little PR to add a method to the client extension in order to add the possibility to manually close the connection to Redis in case it's not garbage collected in time and thus leak stale connection to redis